### PR TITLE
Fix typo and make JWT key ID property optional for HS256-signed JWTs

### DIFF
--- a/my-dev-portal-api/app.js
+++ b/my-dev-portal-api/app.js
@@ -27,7 +27,7 @@ const {
   getUnifiedCustomerId,
   getUnifiedCustomerIdCached,
 } = require("./services/commonUtils");
-const { BillingProvider } = require("./services/BillingProvider");
+const { BillingProvider } = require("./services/billingProvider");
 
 const app = express();
 app.use(express.static(path.join(__dirname)));

--- a/plugins/jwt/README.md
+++ b/plugins/jwt/README.md
@@ -17,10 +17,10 @@ In the `my-dev-portal-api` project, you'll need to set the following envvars in 
 |-----------|-----------|
 |PLUGIN_JWT_ALGORITHM|Algorithm to use for signing JWT. The developer portal supports `RS256` and `HS256` algorithms.|
 |PLUGIN_JWT_SECRET|Secret used for signing. Make sure to keep private and store in a robust key store.|
-|PLUGIN_JWT_USER_ID_FIELD|The field in the claims that contains user id. Defaults to "sub"|
-|PLUGIN_JWT_COMPANY_ID_FIELD|The field in the claims that contains company (customer) id. Defaults to "org_id"|
-|PLUGIN_JWT_EXPIRES_IN|How long JWT is valid. Can be a number in seconds or use shorthand like "30d"|
-|PLUGIN_JWT_KID|The key ID value of a JWT that uniquely identifies the JWT in a JWKS (JSON Web Key Set).|
+|PLUGIN_JWT_USER_ID_FIELD|The field in the claims that contains user id. Defaults to "sub".|
+|PLUGIN_JWT_COMPANY_ID_FIELD|The field in the claims that contains company (customer) id. Defaults to "org_id".|
+|PLUGIN_JWT_EXPIRES_IN|How long JWT is valid. Can be a number in seconds or use shorthand like "30d".|
+|PLUGIN_JWT_KID|The key ID value of a JWT that uniquely identifies the JWT in a JWKS (JSON Web Key Set). You must set this key for RS256-signed JWTs.|
 
 ### Configuring API gateway or app
 

--- a/plugins/jwt/jwtProvisioningPlugin.js
+++ b/plugins/jwt/jwtProvisioningPlugin.js
@@ -33,7 +33,7 @@ class JwtProvisioningPlugin extends ProvisioningPlugin {
       const token = jwt.sign(payload, this.jwtSecret, { 
         algorithm: this.jwtAlgorithm,
         expiresIn: this.jwtExpiresIn,
-        keyid: this.jwtKid, 
+        ...(this.jwtKid && { keyid: this.jwtKid }), 
       });
 
       console.log(`Generated new JWT with claims ${JSON.stringify(this.jwtExpiresIn)}`)


### PR DESCRIPTION
- Fixes typo in import statement that breaks the app.
- Makes the `env.PLUGIN_JWT_KID` dev portal API environment variable optional for HS256-signed JWTs (for HS256 this property doesn't make sense so just a small update for UX when a user doesn't want to specify this variable)